### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-update-env.yml
+++ b/.github/workflows/auto-update-env.yml
@@ -1,6 +1,10 @@
 
 name: Update Conda Environment
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: "0 0 * * 0"  # Runs at midnight on Sunday


### PR DESCRIPTION
Potential fix for [https://github.com/willisbillis/MAPseq/security/code-scanning/1](https://github.com/willisbillis/MAPseq/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required for the workflow. The workflow needs `contents: write` to push changes to the repository and `pull-requests: write` to create a pull request. Adding these permissions ensures the workflow has only the access it needs and no more.

The `permissions` block will be added at the root level of the workflow file, applying to all jobs in the workflow. This approach is concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
